### PR TITLE
Eliminate trailing dots applied to folded text.

### DIFF
--- a/ftplugin/wiki.vim
+++ b/ftplugin/wiki.vim
@@ -60,8 +60,10 @@ endfunction
 
 " }}}1
 function! WikiFoldText() abort " {{{1
-  let l:line = getline(v:foldstart)
-  let l:text = substitute(l:line, '^\s*', repeat(' ',indent(v:foldstart)), '')
+  let l:end_chars = repeat(' ', winwidth(0))
+  let l:lines_count = v:foldend - v:foldstart + 1
+  let l:lines_text = l:lines_count ==# 1 ? ' line' : ' lines'
+  let l:text = getline(v:foldstart).' ('.l:lines_count.lines_text.')'.l:end_chars
   return l:text
 endfunction
 


### PR DESCRIPTION
@lervag  - I offer this simple modification to suppress trailing dots that are applied to folds.  I modeled this change after [vim-most-minimal-folds](https://github.com/vim-utils/vim-most-minimal-folds).  


Before Change:
```
  # Fold 01.........
  # Fold 02.........
```

After Change:
```
  # Fold 01 (7 lines)
  # Fold 02 (3 lines)
```